### PR TITLE
feat: BES script

### DIFF
--- a/BancoEstado/scriptgp.ps1
+++ b/BancoEstado/scriptgp.ps1
@@ -1,0 +1,160 @@
+###copiar para abajo ####
+
+Import-Module ActiveDirectory
+
+$BasePath = "C:\temp\Export-ADGroups"
+if (-not (Test-Path $BasePath)) { New-Item -Path $BasePath -ItemType Directory | Out-Null }
+
+# Función genérica para obtener letras A-Z + Otros
+function Get-Alphabet {
+    return @([char[]](65..90)) + "_Otros"
+}
+
+function GruposSinUsuarios {
+    Write-Host "Buscando grupos sin usuarios (divididos por letra)..."
+    foreach ($letra in Get-Alphabet) {
+        $path = Join-Path $BasePath "$letra"
+        if (-not (Test-Path $path)) { New-Item -Path $path -ItemType Directory | Out-Null }
+
+        if ($letra -eq "_Otros") {
+            $filtro = '-not(Name -like "[A-Z]*")'
+        } else {
+            $filtro = "Name -like '$letra*'"
+        }
+
+        $grupos = Get-ADGroup -Filter $filtro -Properties Members | Where-Object { $_.Members.Count -eq 0 }
+        if ($grupos) {
+            $file = Join-Path $path "Grupos_sin_usuarios.csv"
+            $grupos | Select-Object Name, DistinguishedName | Export-Csv -Path $file -NoTypeInformation -Encoding UTF8 -Append
+            Write-Host "Exportado: $file"
+        }
+    }
+}
+
+function GruposEnUso {
+    $path = Join-Path $BasePath "GruposEnUso"
+    if (-not (Test-Path $path)) { New-Item -Path $path -ItemType Directory | Out-Null }
+    $file = Join-Path $path "GruposEnUso.csv"
+
+    Write-Host "Identificando grupos en uso actualmente (divididos por letra)..."
+    foreach ($letra in Get-Alphabet) {
+        if ($letra -eq "_Otros") {
+            $filtro = { -not (Name -like "[A-Z]*") }
+        } else {
+            $filtro = { Name -like "$letra*" }
+        }
+
+        $grupos = Get-ADGroup -Filter $filtro -Properties Members, MemberOf
+        $gruposEnUso = $grupos | Where-Object { $_.Members.Count -gt 0 -or $_.MemberOf.Count -gt 0 }
+        if ($gruposEnUso) {
+            $gruposEnUso | Select-Object Name,@{Name="CantidadMiembros";Expression={$_.Members.Count}} | `
+                Export-Csv -Path $file -NoTypeInformation -Encoding UTF8 -Append
+        }
+    }
+    Write-Host "Archivo exportado en $file"
+}
+
+function GruposSinManager {
+    Write-Host "Buscando grupos sin Manager (divididos por letra)..."
+    foreach ($letra in Get-Alphabet) {
+        $path = Join-Path $BasePath "$letra"
+        if (-not (Test-Path $path)) { New-Item -Path $path -ItemType Directory | Out-Null }
+
+        if ($letra -eq "_Otros") {
+            $filtro = { -not (Name -like "[A-Z]*") }
+        } else {
+            $filtro = { Name -like "$letra*" }
+        }
+
+        $grupos = Get-ADGroup -Filter $filtro -Properties ManagedBy | Where-Object { -not $_.ManagedBy }
+        if ($grupos) {
+            $file = Join-Path $path "Grupos_sin_manager.csv"
+            $grupos | Select-Object Name, DistinguishedName | Export-Csv -Path $file -NoTypeInformation -Encoding UTF8 -Append
+            Write-Host "Exportado: $file"
+        }
+    }
+}
+
+function GruposConAnidados {
+    Write-Host "Buscando grupos con anidados (divididos por letra)..."
+    foreach ($letra in Get-Alphabet) {
+        $path = Join-Path $BasePath "$letra"
+        if (-not (Test-Path $path)) { New-Item -Path $path -ItemType Directory | Out-Null }
+
+        if ($letra -eq "_Otros") {
+            $filtro = { -not (Name -like "[A-Z]*") }
+        } else {
+            $filtro = { Name -like "$letra*" }
+        }
+
+        $grupos = Get-ADGroup -Filter $filtro -Properties Members
+        foreach ($grupo in $grupos) {
+            $nested = @()
+            foreach ($m in $grupo.Members) {
+                try {
+                    $obj = Get-ADObject -Identity $m -Properties ObjectClass, DistinguishedName
+                    if ($obj.ObjectClass -eq "group") {
+                        $nested += [PSCustomObject]@{
+                            GrupoPadre        = $grupo.Name
+                            GrupoAnidado      = $obj.Name
+                            DistinguishedName = $obj.DistinguishedName
+                        }
+                    }
+                } catch {}
+            }
+            if ($nested.Count -gt 0) {
+                $file = Join-Path $path "$($grupo.Name).csv"
+                $nested | Export-Csv -Path $file -NoTypeInformation -Encoding UTF8
+                Write-Host "Archivo creado: $file"
+            }
+        }
+    }
+}
+
+function EliminarGruposSinUsuarios {
+    Write-Host "Eliminando grupos sin usuarios (divididos por letra)..."
+    foreach ($letra in Get-Alphabet) {
+        if ($letra -eq "_Otros") {
+            $filtro = { -not (Name -like "[A-Z]*") }
+        } else {
+            $filtro = { Name -like "$letra*" }
+        }
+
+        $grupos = Get-ADGroup -Filter $filtro -Properties Members | Where-Object { $_.Members.Count -eq 0 }
+        foreach ($g in $grupos) {
+            Write-Host "Eliminando grupo: $($g.Name)" -ForegroundColor Red
+            Remove-ADGroup -Identity $g.DistinguishedName -Confirm:$false
+        }
+    }
+    Write-Host "Proceso completado." -ForegroundColor Green
+}
+
+function MostrarMenu {
+    Clear-Host
+    Write-Host "====================================" -ForegroundColor Cyan
+    Write-Host "   Script de Gestión de Grupos AD   " -ForegroundColor Cyan
+    Write-Host "====================================" -ForegroundColor Cyan
+    Write-Host "1. Identificar grupos sin usuarios (Exportar CSV)"
+    Write-Host "2. Identificar grupos en uso (Exportar CSV)"
+    Write-Host "3. Identificar grupos sin manager (Exportar CSV)"
+    Write-Host "4. Identificar grupos con grupos anidados (Exportar CSV)"
+    Write-Host "5. Eliminar grupos sin usuarios"
+    Write-Host "6. Salir"
+    Write-Host "===================================="
+}
+
+do {
+    MostrarMenu
+    $opcion = Read-Host "Seleccione una opción"
+    switch ($opcion) {
+        "1" { GruposSinUsuarios; Pause }
+        "2" { GruposEnUso; Pause }
+        "3" { GruposSinManager; Pause }
+        "4" { GruposConAnidados; Pause }
+        "5" { EliminarGruposSinUsuarios; Pause }
+        "6" { Write-Host "Saliendo..."; break }
+        Default { Write-Host "Opción inválida, intente nuevamente." -ForegroundColor Red; Pause }
+    }
+} while ($opcion -ne "6")
+
+ 

--- a/Servel/script.ps1
+++ b/Servel/script.ps1
@@ -1,0 +1,71 @@
+# Obtener la fecha límite (hace 60 días)
+$fechaLimite = (Get-Date).AddDays(-60)
+
+# 1. Contar cuentas de usuario desactivadas y exportar detalles a CSV con todos los atributos
+$usuariosDesactivados = Get-ADUser -Filter 'Enabled -eq $false' -Properties *
+Write-Host "Usuarios desactivados: $($usuariosDesactivados.Count)"
+$usuariosDesactivados | Select-Object * | Export-Csv -Path "C:\temp\usuarios_desactivados.csv" -NoTypeInformation -Encoding UTF8 -Delimiter ';'
+
+# 2. Cuentas activas que no han iniciado sesión en 60 días
+$usuariosInactivos = Get-ADUser -Filter 'Enabled -eq $true' -Properties * | Where-Object {
+    !$_.LastLogonDate -or $_.LastLogonDate -lt $fechaLimite
+}
+Write-Host "Usuarios activos sin login en 60 días: $($usuariosInactivos.Count)"
+$usuariosInactivos | Select-Object * | Export-Csv -Path "C:\temp\usuarios_activos_inactivos.csv" -NoTypeInformation -Encoding UTF8 -Delimiter ';'
+
+# 3. Objetos máquina activos que no han iniciado sesión en 60 días
+$maquinasInactivas = Get-ADComputer -Filter 'Enabled -eq $true' -Properties *
+$maquinasInactivas = $maquinasInactivas | Where-Object {
+    !$_.LastLogonDate -or $_.LastLogonDate -lt $fechaLimite
+}
+Write-Host "Máquinas activas sin login en 60 días: $($maquinasInactivas.Count)"
+$maquinasInactivas | Select-Object * | Export-Csv -Path "C:\temp\maquinas_activas_inactivas.csv" -NoTypeInformation -Encoding UTF8 -Delimiter ';'
+
+# 4. Generar un informe resumen en HTML con enlaces a los CSV exportados
+
+$reporteHtml = @"
+<html>
+<head>
+    <title>Informe de Cuentas y Equipos Inactivos</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        table { border-collapse: collapse; width: 60%; margin-bottom: 20px; }
+        th, td { border: 1px solid #dddddd; text-align: left; padding: 8px; }
+        th { background-color: #f2f2f2; }
+        h2 { color: #2e6c80; }
+    </style>
+</head>
+<body>
+    <h1>Informe de Cuentas y Equipos Inactivos</h1>
+    <p>Generado por: Consultor Senior de TI</p>
+    <p>Fecha de generación: $(Get-Date -Format "yyyy-MM-dd HH:mm")</p>
+    <h2>Resumen</h2>
+    <table>
+        <tr>
+            <th>Tipo</th>
+            <th>Cantidad</th>
+            <th>Detalle</th>
+        </tr>
+        <tr>
+            <td>Usuarios desactivados</td>
+            <td>$($usuariosDesactivados.Count)</td>
+            <td><a href="C:\temp\usuarios_desactivados.csv">Descargar CSV</a></td>
+        </tr>
+        <tr>
+            <td>Usuarios activos sin login en 60 días</td>
+            <td>$($usuariosInactivos.Count)</td>
+            <td><a href="C:\temp\usuarios_activos_inactivos.csv">Descargar CSV</a></td>
+        </tr>
+        <tr>
+            <td>Máquinas activas sin login en 60 días</td>
+            <td>$($maquinasInactivas.Count)</td>
+            <td><a href="C:\temp\maquinas_activas_inactivas.csv">Descargar CSV</a></td>
+        </tr>
+    </table>
+    <p>Este informe fue generado automáticamente para su revisión y acciones correspondientes.</p>
+</body>
+</html>
+"@
+
+$reporteHtml | Set-Content -Path "C:\temp\informe_resumen.html" -Encoding UTF8
+Write-Host "Informe resumen exportado a C:\temp\informe_resumen.html"


### PR DESCRIPTION
This pull request introduces two new PowerShell scripts to automate Active Directory (AD) management and reporting tasks for two different organizations. The scripts provide tools for group management and user/machine inactivity reporting, including CSV exports and HTML summaries.

**BancoEstado Active Directory Group Management Script:**

_Group management and reporting:_

* Adds `scriptgp.ps1`, a comprehensive script for managing AD groups, including functions to:
  - Identify and export groups without users, groups in use, groups without a manager, and groups with nested groups, all organized by the starting letter of the group name.
  - Export results to CSV files in a structured directory (`C:\temp\Export-ADGroups`).
* Provides an interactive menu for users to select actions, including the option to delete groups without users.

**Servel User and Computer Inactivity Reporting Script:**

_User and computer inactivity reporting:_

* Adds `script.ps1` to automate reporting on AD users and computers, including:
  - Exporting all disabled user accounts to a CSV file.
  - Exporting active user accounts that haven't logged in for 60 days to a CSV file.
  - Exporting active computer objects that haven't logged in for 60 days to a CSV file.
  - Generating an HTML summary report with counts and download links to the exported CSVs.